### PR TITLE
bind gaussian

### DIFF
--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var phi = require( 'gaussian' )( 0, 1 ).pdf;
+var gaussian = require( 'gaussian' )( 0, 1 );
+var phi = gaussian.pdf.bind(gaussian);
 var d = require( 'euclidean-distance' );
 var _   = require( 'lodash' );
 var jStat = require( 'jStat' ).jStat;


### PR DESCRIPTION
For some reason, when using the `gaussian` function in my Meteor environment it does not work because `this === Window` inside the `gaussian` method.

This PR should make it safe.