### PR TITLE
Fix the sign in the silverman function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ ns.silverman = function( x ) {
     var num = 4 * Math.pow( stdev( x ), 5 );
     var denom = 3 * x.length;
     var divisionResult = num / denom;
-    return Math.pow( divisionResult, -0.2 );
+    return Math.pow( divisionResult, 0.2 );
 };
 
 // kernel density estimation

--- a/test/test.js
+++ b/test/test.js
@@ -91,6 +91,6 @@ describe(".silverman()", function(){
   it("returns an optimal bandwith", function(){
     var x = [0,0,1,1,1,2,2];
     var h = kernel.silverman(x);
-    expect(h).to.be.above(0);
+    expect(h).to.be.closeTo(0.586, 0.01);
   });
 });


### PR DESCRIPTION
Good way to sanity check if you're in doubt this is right: the output should scale linearly with the input.
so silverman([0,0,1,1,1,2,2]) =~ 0.586 => silverman([0,0,10,10,10,20,20]) =~ 5.86

Note that some descriptions of the silverman function have a power to the (-1/5)th in them, but that's only right if the rest of the formula is flipped around too.